### PR TITLE
document behavior

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,16 +37,17 @@ optional arguments:
 
 ### Firmware problems
 
-The most recent firmware version of the Tonie box has a few drawbacks:
+The firmware of the Tonie box has drawbacks **when it can connect to the internet via WiFi**:
 
-* Reading custom NFC tags while connected to the internet will result in the deletion of the associated audio data.
-* When the box is idle and connected to the internet it will set the "hidden" FAT filesystem attribute for custom audio data files. This will have the effect of enabling "live" mode for these files => the NFC tag will always trigger playback of the beginning of the file (no matter whether another NFC tag was used in-between). 
-* When the box boots (i.e. after re-connecting the battery) it will always enable Wi-Fi and therefore apply the "hidden" filesystem attribute for custom audio files as described above. 
-  
+* Reading custom NFC tags will result in the deletion of the associated audio data.
 
-Other tidbits:
+* Reading an official Tonie that has custom content stored on the box will delete the custom content and download the original files again, unless the internal timestamps are identical
 
-(*found somewhere else; unconfirmed*) If you replace an official Tonie with custom content and keep the same `timestamp` as the official file, the replaced content will even work when the box is online.  
+* On startup, or when idle, it will set the "hidden" FAT filesystem attribute for custom audio data files with incongruous internal timestamps. This enables "live" mode for these files and the NFC tag will always trigger playback from the beginning of the file (no matter whether another NFC tag was used in-between).
+  You can only enter the offline mode of the box *after* startup, so to avoid this effect you need to block the box on your wireless network before connecting it to the batteries again.
+
+The latter two issues can be circumvented by using the `timestamp` that is officially associated with the Tonie for the custom content.
+You can identify this timestamp through `./opus2tonie.py --info` and generate your custom files with the optional `--ts <timestamp>` parameter.
 
 ### Tonie header
 

--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@
 
 ### Current state
 
-A first test produced files which were accepted by the Tonie box.
+At the time of writing the script can produce files that can be played by the Tonie box.
 
 ### Usage
 

--- a/opus2tonie.py
+++ b/opus2tonie.py
@@ -106,8 +106,10 @@ class OpusPacket:
         elif self.config_value in [19, 23, 27, 31]:
             return 20
         else:
-            raise RuntimeError("Please add frame size for config value {}".format(self.config_value))
-
+            raise RuntimeError(
+                "Found config value {} in opus packet, but CELT-only encodings (16-31) are required by the box.\n" \
+                "Please encode your input files accordingly or fix your encoding pipeline to do so.\n" \
+                "Did you built libopus with custom modes support?".format(self.config_value))
 
     def calc_granule(self):
         return self.frame_size * self.frame_count * SAMPLE_RATE_KHZ


### PR DESCRIPTION
This follows up on our exchange in https://github.com/bailli/opus2tonie/issues/3
and adds details on using the timestamp argument for official tonies after I tested it.