### PR TITLE
Add two more assertions to catch missing librecaptcha

### DIFF
--- a/opus2tonie.py
+++ b/opus2tonie.py
@@ -847,6 +847,8 @@ def get_t2s_token():
 
 
 def get_t2s_base64_data(text):
+    assert T2S_AVAILABLE, "If you want to use the text2speech Google Cloud \n" \
+                          "service you need to install the librecaptcha package!"
     token = "this-is-definitly-a-token"
     json = {
         "audioConfig": {
@@ -878,6 +880,8 @@ def get_t2s_base64_data(text):
 
 
 def get_t2s_tempfile(ffmpeg_binary, opus_binary, text, bitrate, vbr=True):
+    assert T2S_AVAILABLE, "If you want to use the text2speech Google Cloud \n" \
+                          "service you need to install the librecaptcha package!"
     t2s_base64 = get_t2s_base64_data(text)
 
     if not vbr:


### PR DESCRIPTION
If `librecaptcha` fails to be imported, also there's no `requests`. `get_t2s_base64_data()` is invoked before `get_t2s_token()` so it needs to check for availability of T2S as well, and/or this could be done at the beginning of `get_t2s_tempfile()`.

This my solution may be overkill, `get_t2s_tempfile()` I suppose is the right place for the check.

This change addresses issue #7